### PR TITLE
Feat/props_update_on_change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# ignore personal setup for testing during dev
+/src/dev/
+index.html

--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ npm run dev
 
 # 🏗️ Other documentation under construction 🏗️
 
+# Props
+
+Note: some props require odd syntax to pass due to how tableau has hyphenated fields which JS is allergic to. To sidestep future compatibility issues, this library recommends using an odd syntax which involes spreading a temporary object. An example of this syntax can be seen in the simple example below with `hide-tabs`.
+
+```js
+<TableauEmbed
+  sourceUrl="https://public.tableau.com/views/WorldIndicators/GDPpercapita"
+  {...{ "hide-tabs": true }}
+/>
+```
+
+["hide-tabs"] - note: to set to false (and show tabs), pass `undefined` not `false`. Tableau's API appears to cast this prop to a string which makes `false`-> `"false"` -> which is truthy (i.e., `boolean("false") === true` is true).
+
 # Limitations
 
 **Contributions welcome!!**

--- a/example/react-tableau-embed-live-examples/src/App.css
+++ b/example/react-tableau-embed-live-examples/src/App.css
@@ -17,6 +17,15 @@
   margin: 1rem;
 }
 
+form.props-form > label,
+.form > .button {
+  margin: 10px;
+}
+
+.props-form {
+  margin: 3px;
+}
+
 .example-spacer {
   height: 3rem;
   width: 100vw;

--- a/example/react-tableau-embed-live-examples/src/index.css
+++ b/example/react-tableau-embed-live-examples/src/index.css
@@ -37,6 +37,7 @@ h1 {
   line-height: 1.1;
 }
 
+.button,
 button {
   border-radius: 8px;
   border: 1px solid transparent;
@@ -48,9 +49,12 @@ button {
   cursor: pointer;
   transition: border-color 0.25s;
 }
+.button:hover,
 button:hover {
   border-color: #646cff;
 }
+.button:focus,
+.button:focus-visible,
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
@@ -64,6 +68,7 @@ button:focus-visible {
   a:hover {
     color: #747bff;
   }
+  .button,
   button {
     background-color: #f9f9f9;
   }

--- a/example/react-tableau-embed-live-examples/src/tableau_examples/InteractiveProps.tsx
+++ b/example/react-tableau-embed-live-examples/src/tableau_examples/InteractiveProps.tsx
@@ -1,0 +1,102 @@
+import * as React from "react";
+import "./App.css";
+import { TableauEmbed } from "@stoddabr/react-tableau-embed-live";
+
+interface TableauPropsEditor {
+  height: number;
+  width: number;
+  "hide-tabs"?: boolean;
+  sourceUrl: string;
+}
+
+const defaultProps = {
+  height: 500,
+  width: 500,
+  // "hide-tabs": false,
+  sourceUrl: "https://public.tableau.com/views/WorldIndicators/GDPpercapita",
+};
+
+function InteractiveProps() {
+  const [props, setProps] = React.useState<TableauPropsEditor>(defaultProps);
+  const [draft, setDraft] = React.useState<TableauPropsEditor>(defaultProps);
+
+  const handleChange: React.ChangeEventHandler<any> = (e) => {
+    console.log({ e });
+    const name = e.target.name;
+    const value = e.target.value;
+    if (name === "hide-tabs") {
+      setDraft((values) => ({
+        ...values,
+        [name]: !draft["hide-tabs"] ? true : undefined,
+      }));
+      return;
+    }
+    setDraft((values) => ({ ...values, [name]: value }));
+  };
+
+  const updateProps = () => {
+    setProps(draft);
+  };
+
+  return (
+    <div className="App">
+      <h3>Update Props</h3>
+      <form
+        className="props-form"
+        onSubmit={(e) => {
+          updateProps();
+          e.preventDefault();
+        }}
+      >
+        <label>
+          Height:
+          <input
+            type="text"
+            name="height"
+            value={draft.height || ""}
+            onChange={handleChange}
+          />
+        </label>
+        <label>
+          Width:
+          <input
+            type="text"
+            name="width"
+            value={draft.width || ""}
+            onChange={handleChange}
+          />
+        </label>
+        <label>
+          Hide-tabs:
+          <input
+            type="checkbox"
+            name="hide-tabs"
+            checked={draft["hide-tabs"]}
+            onChange={handleChange}
+          />
+        </label>
+        <label>
+          Source:
+          <input
+            type="text"
+            name="sourceUrl"
+            value={draft.sourceUrl || ""}
+            onChange={handleChange}
+          />
+        </label>
+        <br />
+        <input type="submit" value="Update Props" className="button" />
+      </form>
+      <div style={{ height: 30 }} />
+
+      <TableauEmbed {...props} />
+
+      <div>
+        <h3>Active props:</h3>
+        <p>{JSON.stringify(props)}</p>
+      </div>
+    </div>
+  );
+}
+
+export default InteractiveProps;

--- a/example/react-tableau-embed-live-examples/src/tableau_examples/index.ts
+++ b/example/react-tableau-embed-live-examples/src/tableau_examples/index.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import AddRemoveFilters from "./AddRemoveFilters";
 import Basic from "./Basic";
 import EventListeners from "./EventListeners";
+import InteractiveProps from "./InteractiveProps";
 
 export interface TableauExample {
   component: () => JSX.Element; //React.FC;
@@ -10,6 +11,7 @@ export interface TableauExample {
 
 const examples: TableauExample[] = [
   { component: Basic, name: "Basic Embed" },
+  { component: InteractiveProps, name: "Interactive Props" },
   { component: AddRemoveFilters, name: "Add/Remove Filter Buttons" },
   { component: EventListeners, name: "Event Listeners" },
 ];

--- a/src/lib/TableauEmbed/TableauViz.tsx
+++ b/src/lib/TableauEmbed/TableauViz.tsx
@@ -78,7 +78,6 @@ declare global {
 
 function TableauViz(props: TableauVizCustomProps, ref: TableauVizRef) {
   const vizRef = React.useRef<any>(null);
-
   React.useImperativeHandle(ref, () => vizRef.current);
 
   // set event listeners

--- a/src/lib/TableauEmbed/index.tsx
+++ b/src/lib/TableauEmbed/index.tsx
@@ -32,7 +32,10 @@ function TableauEmbed(props: TableauEmbed, ref: TableauVizRef) {
   }
 
   if (!component) {
-    console.error("finished loading but component is falsy");
+    console.error(
+      "Finished loading but component is falsy. Error message: " +
+        tableau.errorMessage
+    );
     return <h3>component error: falsy"</h3>;
   }
 


### PR DESCRIPTION
Fixes issue where props would not update when changed by parent.

Fix involves moving the inner tableau component outside of a useState store inside of useTableau. Instead, selectively renders the component based on the state of the API loader. Details about this issue discussed here: https://stackoverflow.com/questions/66919014/is-it-a-good-idea-to-store-components-in-state

Note: "reinit tableau on prop change" is misleading. It imperatively describes one solution I thought would be necessary but was not. The issue was with the component being in a useState inside of the useTableau hook and not with the Tableau API as I thought. 