### PR TITLE
Update useTableau Hook

### DIFF
--- a/src/lib/TableauEmbed/UseTableau/index.tsx
+++ b/src/lib/TableauEmbed/UseTableau/index.tsx
@@ -68,7 +68,7 @@ export default function useTableau(args: UseTableauParams): UseTableauReturn {
   const [errMsg, setErrMsg] = React.useState<string | undefined>();
 
   const hostname = extractHostname(args.sourceUrl);
-  const apiUrl = buildTableauApiUrl(hostname);
+  const apiUrl = buildTableauApiUrl(hostname, args.version, !!args.version);
 
   const { status: apiLoadStatus, errorMessage: apiErrorMessage } =
     useScript(apiUrl);


### PR DESCRIPTION
Pass args.version to the apiUrl and change the function call to use the minified version.

Both changes are to better reflect the readme:
"The version of the Tableau Embedding API to use. Defaults to "latest" which may change if you use Tableau Server or Cloud. Will always minify. If using a custom version[...]"