### PR TITLE
Add onEventListenerVizLoadErrorEvent

### DIFF
--- a/src/lib/TableauEmbed/ScrapedTableauTypes/Enums.ts
+++ b/src/lib/TableauEmbed/ScrapedTableauTypes/Enums.ts
@@ -326,6 +326,11 @@ export enum TableauEventType {
    * @category Viewing
    */
   StoryPointSwitched = "storypointswitched",
+
+  /**
+   * An event that signals an error while loading the webcomponent.
+   */
+  VizLoadError = "vizloaderror",
 }
 
 /**

--- a/src/lib/TableauEmbed/ScrapedTableauTypes/VizInterfaces.ts
+++ b/src/lib/TableauEmbed/ScrapedTableauTypes/VizInterfaces.ts
@@ -616,3 +616,51 @@ export interface CustomParameter {
    */
   value: string;
 }
+
+export interface VizLoadErrorEvent extends Event {
+  detail: {
+    /**
+     * The error code
+     */
+    _errorCode:
+      | "auth-failed"
+      | "browser-not-capable"
+      | "download-workbook-not-allowed"
+      | "event-initialization-error"
+      | "filter-cannot-be-performed"
+      | "filter-missing-not-implemented"
+      | "wrong-implementation"
+      | "incompatible-version-error"
+      | "index-out-of-range"
+      | "internal-error"
+      | "invalid-custom-view-name"
+      | "invalid-date-parameter"
+      | "invalid-parameter"
+      | "invalid-size"
+      | "invalid-size-behavior"
+      | "invalid-size-behavior-on-worksheet"
+      | "invalid-url"
+      | "missing-max-size"
+      | "missing-min-max-size"
+      | "missing-min-size"
+      | "missing-parameter"
+      | "missing-range-n-for-relative-date-filters"
+      | "no-url-for-hidden-worksheet"
+      | "no-url-or-parent-element-not-found"
+      | "not-active-sheet"
+      | "not-implemented"
+      | "null-or-empty-parameter"
+      | "sheet-not-in-workbook"
+      | "stale-data-reference"
+      | "storypoint-id-mismatch"
+      | "unknown-auth-error"
+      | "unknown-dialog-type"
+      | "unsupported-event-name"
+      | "viz-already-in-manager"
+      | "invalid-filter-field-name";
+    /**
+     * The error message
+     */
+    _message: string;
+  };
+}

--- a/src/lib/TableauEmbed/TableauViz.tsx
+++ b/src/lib/TableauEmbed/TableauViz.tsx
@@ -9,7 +9,7 @@
 import * as React from "react";
 import { TableauEventType } from "./ScrapedTableauTypes/Enums";
 import { FilterUpdateType } from "./ScrapedTableauTypes/ExternalContract_Shared_Namespaces_Tableau";
-import { TableauVizRef, VizChildElements, FilterParameters, VizParameter, CustomParameter } from "./types";
+import { TableauVizRef, VizChildElements, FilterParameters, VizParameter, CustomParameter, VizLoadErrorEvent } from "./types";
 import { type } from "os";
 
 export interface OptionalTableauVizProps {
@@ -61,6 +61,7 @@ export interface OptionalTableauVizProps {
   onEventListenerWorkbookPublished?: (event: any) => void;
   onEventListenerWorkbookPublishedAs?: (event: any) => void;
   onEventListenerWorkbookReadyToClose?: (event: any) => void;
+  onEventListenerVizLoadErrorEvent?: (event: VizLoadErrorEvent) => void;
 }
 
 export interface TableauVizCustomProps extends OptionalTableauVizProps {
@@ -181,6 +182,10 @@ function TableauViz(props: TableauVizCustomProps, ref: TableauVizRef) {
           TableauEventType.WorkbookReadyToClose,
           props.onEventListenerWorkbookReadyToClose
         );
+      if (props.onEventListenerVizLoadErrorEvent)
+        viz.addEventListener(
+          TableauEventType.VizLoadError, 
+          props.onEventListenerVizLoadErrorEvent)
       return () => {
         if (props.onEventListenerCustomMarkContextMenuEvent)
           viz.removeEventListener(


### PR DESCRIPTION
Currently VizLoadError will only output to the console.

![image](https://github.com/stoddabr/react-tableau-embed-live/assets/15997448/eea32ea2-f539-4dd8-95af-d0ddcfc41ae9)

Meaning there is no way to catch them and deal with accordingly.

This PR adds an event listener 'onEventListenerVizLoadErrorEvent'

Scraped all possible error messages possible from the tableau embedding api reference.